### PR TITLE
SVC-1119 implement deletes in connect jdbc

### DIFF
--- a/docs/sink-connector/sink_config_options.rst
+++ b/docs/sink-connector/sink_config_options.rst
@@ -70,6 +70,12 @@ Writes
   * Valid Values: [0,...]
   * Importance: medium
 
+``delete.enabled``
+  Whether to treat ``null`` record values as deletes. If ``true``, requires ``pk.mode`` to be ``record_key``.
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
 .. _sink-pk-config-options:
 
 Data Mapping

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -342,6 +342,12 @@ public interface DatabaseDialect extends ConnectionProvider {
       Collection<ColumnId> nonKeyColumns
   );
 
+  String buildDeleteStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  );
+
   /**
    * Build the UPSERT or MERGE prepared statement expression to either insert a new record into the
    * given table or update an existing record in that table Variables for each key column should
@@ -401,10 +407,12 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   StatementBinder statementBinder(
       PreparedStatement statement,
+      PreparedStatement deleteStatement,
       JdbcSinkConfig.PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      JdbcSinkConfig.InsertMode insertMode
+      JdbcSinkConfig.InsertMode insertMode,
+      JdbcSinkConfig config
   );
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1361,7 +1361,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       builder.append(" WHERE ");
     }
 
-    builder.append("id = 1 AND author = \"Tom Robbins\" AND title = \"Villa Incognito\"");
+    builder.append("id = ?");
     /*
     builder.append("(");
     builder.appendList()

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1348,6 +1348,34 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return builder.toString();
   }
 
+  public String buildDeleteStatement(
+          TableId table,
+          Collection<ColumnId> keyColumns,
+          Collection<ColumnId> nonKeyColumns
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("DELETE FROM ");
+    builder.append(table);
+
+    if (!keyColumns.isEmpty()) {
+      builder.append(" WHERE ");
+    }
+
+    builder.append("id = 1 AND author = \"Tom Robbins\" AND title = \"Villa Incognito\"");
+    /*
+    builder.append("(");
+    builder.appendList()
+            .delimitedBy(",")
+            .transformedBy(ExpressionBuilder.columnNames())
+            .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES(");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(")");
+    */
+
+    return builder.toString();
+  }
+
   @Override
   public String buildUpdateStatement(
       TableId table,
@@ -1384,18 +1412,22 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   @Override
   public StatementBinder statementBinder(
       PreparedStatement statement,
+      PreparedStatement deleteStatement,
       PrimaryKeyMode pkMode,
       SchemaPair schemaPair,
       FieldsMetadata fieldsMetadata,
-      InsertMode insertMode
+      InsertMode insertMode,
+      JdbcSinkConfig config
   ) {
     return new PreparedStatementBinder(
         this,
         statement,
+        deleteStatement,
         pkMode,
         schemaPair,
         fieldsMetadata,
-        insertMode
+        insertMode,
+        config
     );
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1361,17 +1361,11 @@ public class GenericDatabaseDialect implements DatabaseDialect {
       builder.append(" WHERE ");
     }
 
-    builder.append("id = ?");
-    /*
-    builder.append("(");
     builder.appendList()
-            .delimitedBy(",")
+            .delimitedBy("AND")
             .transformedBy(ExpressionBuilder.columnNames())
-            .of(keyColumns, nonKeyColumns);
-    builder.append(") VALUES(");
-    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
-    builder.append(")");
-    */
+            .of(keyColumns)
+            .append(" = ? ");
 
     return builder.toString();
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -127,10 +126,10 @@ public class BufferedRecords {
       final String insertSql = getInsertSql();
       final String deleteSql = getDeleteSql();
       log.info(
-        "{} sql: {} deleteSql: {} meta: {}",
-        config.insertMode,
-        deleteSql,
-        fieldsMetadata);
+              "{} sql: {} deleteSql: {} meta: {}",
+              config.insertMode,
+              deleteSql,
+              fieldsMetadata);
       close();
       updatePreparedStatement = connection.prepareStatement(insertSql);
       preparedStatementBinder = dbDialect.statementBinder(
@@ -167,9 +166,11 @@ public class BufferedRecords {
     if (records.isEmpty()) {
       return new ArrayList<>();
     }
+
     for (SinkRecord record : records) {
       preparedStatementBinder.bindRecord(record);
     }
+
     int totalUpdateCount = 0;
     boolean successNoInfo = false;
     for (int updateCount : updatePreparedStatement.executeBatch()) {
@@ -290,6 +291,8 @@ public class BufferedRecords {
               asColumns(fieldsMetadata.keyFieldNames),
               asColumns(fieldsMetadata.nonKeyFieldNames)
           );
+          break;
+        default:
           break;
       }
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -133,8 +133,8 @@ public class BufferedRecords {
       close();
       updatePreparedStatement = connection.prepareStatement(insertSql);
       preparedStatementBinder = dbDialect.statementBinder(
-              null,
               updatePreparedStatement,
+              null,
               config.pkMode,
               schemaPair,
               fieldsMetadata,

--- a/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/BufferedRecords.java
@@ -125,9 +125,10 @@ public class BufferedRecords {
       );
       final String insertSql = getInsertSql();
       final String deleteSql = getDeleteSql();
-      log.info(
-              "{} sql: {} deleteSql: {} meta: {}",
+      log.debug(
+              "insertMode {}: sql: {} deleteSql: {} meta: {}",
               config.insertMode,
+              insertSql,
               deleteSql,
               fieldsMetadata);
       close();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -101,7 +101,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public static final String DELETE_ENABLED = "delete.enabled";
   private static final String DELETE_ENABLED_DEFAULT = "false";
   private static final String DELETE_ENABLED_DOC =
-          "Whether to treat ``null`` record values as deletes. Requires ``pk.mode`` to be ``record_key``.";
+          "Whether to treat ``null`` record values as deletes. Requires ``pk.mode`` to be"
+          + " ``record_key``.";
   private static final String DELETE_ENABLED_DISPLAY = "Enable deletes";
 
   public static final String AUTO_CREATE = "auto.create";

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -98,6 +98,12 @@ public class JdbcSinkConfig extends AbstractConfig {
       + " table, when possible.";
   private static final String BATCH_SIZE_DISPLAY = "Batch Size";
 
+  public static final String DELETE_ENABLED = "delete.enabled";
+  private static final String DELETE_ENABLED_DEFAULT = "false";
+  private static final String DELETE_ENABLED_DOC =
+          "Whether to treat ``null`` record values as deletes. Requires ``pk.mode`` to be ``record_key``.";
+  private static final String DELETE_ENABLED_DISPLAY = "Enable deletes";
+
   public static final String AUTO_CREATE = "auto.create";
   private static final String AUTO_CREATE_DEFAULT = "false";
   private static final String AUTO_CREATE_DOC =
@@ -259,6 +265,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.SHORT,
             BATCH_SIZE_DISPLAY
         )
+        .define(
+            DELETE_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            DELETE_ENABLED_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            DELETE_ENABLED_DOC,
+            WRITES_GROUP,
+            3,
+            ConfigDef.Width.SHORT,
+            DELETE_ENABLED_DISPLAY
+        )
         // Data Mapping
         .define(
             TABLE_NAME_FORMAT,
@@ -356,6 +373,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionPassword;
   public final String tableNameFormat;
   public final int batchSize;
+  public final boolean deleteEnabled;
   public final int maxRetries;
   public final int retryBackoffMs;
   public final boolean autoCreate;
@@ -373,6 +391,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
+    deleteEnabled = getBoolean(DELETE_ENABLED);
     maxRetries = getInt(MAX_RETRIES);
     retryBackoffMs = getInt(RETRY_BACKOFF_MS);
     autoCreate = getBoolean(AUTO_CREATE);

--- a/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/PreparedStatementBinder.java
@@ -94,7 +94,10 @@ public class PreparedStatementBinder implements StatementBinder {
     }
   }
 
-  protected int bindKeyFields(SinkRecord record, int index, PreparedStatement statement) throws SQLException {
+  protected int bindKeyFields(
+          SinkRecord record,
+          int index,
+          PreparedStatement statement) throws SQLException {
     switch (pkMode) {
       case NONE:
         if (!fieldsMetadata.keyFieldNames.isEmpty()) {
@@ -150,7 +153,11 @@ public class PreparedStatementBinder implements StatementBinder {
     return index;
   }
 
-  protected void bindField(PreparedStatement statement, int index, Schema schema, Object value) throws SQLException {
+  protected void bindField(
+          PreparedStatement statement,
+          int index,
+          Schema schema,
+          Object value) throws SQLException {
     dialect.bindField(statement, index, schema, value);
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -75,6 +75,53 @@ public class JdbcDbWriterTest {
   }
 
   @Test
+  public void idempotentDeletes() throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("delete.enabled", "true");
+    props.put("pk.mode", "record_key");
+    props.put("insert.mode", "upsert");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+        .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+        .field("author", Schema.STRING_SCHEMA)
+        .field("title", Schema.STRING_SCHEMA)
+        .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+        .put("author", "Tom Robbins")
+        .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+
+    writer.write(Collections.nCopies(2, record));
+
+    SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
+    writer.write(Collections.nCopies(2, deleteRecord));
+
+    assertEquals(
+        1,
+        sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+          @Override
+          public void read(ResultSet rs) throws SQLException {
+            assertEquals(0, rs.getInt(1));
+          }
+        })
+    );
+  }
+
+  @Test
   public void autoCreateWithAutoEvolve() throws SQLException {
     String topic = "books";
     TableId tableId = new TableId(null, null, topic);

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -122,6 +122,52 @@ public class JdbcDbWriterTest {
   }
 
   @Test
+  public void insertDeleteInsertSameRecord() throws SQLException {
+    String topic = "books";
+    int partition = 7;
+    long offset = 42;
+
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("delete.enabled", "true");
+    props.put("pk.mode", "record_key");
+    props.put("insert.mode", "upsert");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+            .field("id", SchemaBuilder.INT64_SCHEMA);
+
+    Struct keyStruct = new Struct(keySchema).put("id", 0L);
+
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("author", Schema.STRING_SCHEMA)
+            .field("title", Schema.STRING_SCHEMA)
+            .build();
+
+    Struct valueStruct = new Struct(valueSchema)
+            .put("author", "Tom Robbins")
+            .put("title", "Villa Incognito");
+
+    SinkRecord record = new SinkRecord(topic, partition, keySchema, keyStruct, valueSchema, valueStruct, offset);
+    SinkRecord deleteRecord = new SinkRecord(topic, partition, keySchema, keyStruct, null, null, offset);
+    writer.write(Collections.singletonList(record));
+    writer.write(Collections.singletonList(deleteRecord));
+    writer.write(Collections.singletonList(record));
+
+    assertEquals(
+            1,
+            sqliteHelper.select("select count(*) from books", new SqliteHelper.ResultSetReadCallback() {
+              @Override
+              public void read(ResultSet rs) throws SQLException {
+                assertEquals(1, rs.getInt(1));
+              }
+            })
+    );
+  }
+
+  @Test
   public void autoCreateWithAutoEvolve() throws SQLException {
     String topic = "books";
     TableId tableId = new TableId(null, null, topic);

--- a/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/PreparedStatementBinderTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.verify;
 public class PreparedStatementBinderTest {
 
   private DatabaseDialect dialect;
+  private JdbcSinkConfig config;
 
   @Before
   public void beforeEach() {
@@ -64,6 +65,7 @@ public class PreparedStatementBinderTest {
     props.put(JdbcSinkConfig.CONNECTION_PASSWORD, "password");
     JdbcSinkConfig config = new JdbcSinkConfig(props);
     dialect = new GenericDatabaseDialect(config);
+    this.config = config;
   }
 
   @Test
@@ -115,10 +117,12 @@ public class PreparedStatementBinderTest {
     PreparedStatementBinder binder = new PreparedStatementBinder(
         dialect,
         statement,
+        null,
         pkMode,
         schemaPair,
         fieldsMetadata,
-        JdbcSinkConfig.InsertMode.INSERT
+        JdbcSinkConfig.InsertMode.INSERT,
+        config
     );
 
     binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -168,9 +172,11 @@ public class PreparedStatementBinderTest {
         PreparedStatementBinder binder = new PreparedStatementBinder(
                 dialect,
                 statement,
+                null,
                 pkMode,
                 schemaPair,
-                fieldsMetadata, JdbcSinkConfig.InsertMode.UPSERT
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPSERT,
+                config
         );
 
         binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));
@@ -207,9 +213,11 @@ public class PreparedStatementBinderTest {
         PreparedStatementBinder binder = new PreparedStatementBinder(
                 dialect,
                 statement,
+                null,
                 pkMode,
                 schemaPair,
-                fieldsMetadata, JdbcSinkConfig.InsertMode.UPDATE
+                fieldsMetadata, JdbcSinkConfig.InsertMode.UPDATE,
+                config
         );
 
         binder.bindRecord(new SinkRecord("topic", 0, null, null, valueSchema, valueStruct, 0));


### PR DESCRIPTION
This PR is based entirely off of https://github.com/confluentinc/kafka-connect-jdbc/pull/282/files?utf8=%E2%9C%93&diff=split, bringing it up to date with the current 5.0 version.

There is one style error (that I'm not entirely sure how to go about fixing) that will prevent test execution unless you skip it, so feel free to run tests individually via an IDE or if you want to run the whole test suite simply run:

```sh
$ mvn test -Dcheckstyle.skip
```

To package the project as a `.jar` run:
```sh
$ mvn package shade:shade -Dcheckstyle.skip
```

I performed a manual integration test by doing a few things. First you must package the project with the command above. After that you'll want to move the `.jar` into our [Kafka repo](https://github.com/dailymuse/kafka) and overwrite the current kafka-connect jar.

You'll then want to have our [Kafka repo](https://github.com/dailymuse/kafka) up and running, be sure to reference the instructions in that repo for setup. Once all the Kafka related containers are running you'll want to have two local databases up and running in docker. I choose Muselytics database and Web's database. One will act as the source, and the other will act as a sink. 

Next you'll want to decide on a table and some fields from the source database you want to transfer to your sink database. Take a look at the Kafka repo for example source configs, but I'll list mine below:

```json
{
    "name": "debezium-postgresql",
    "config": {
        "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
        "delete.handling.mode": "rewrite",
        "database.user": "dailymuse",
        "database.dbname": "themuse",
        "slot.name": "debezium",
        "tasks.max": "1",
        "transforms": "route",
        "database.server.name": "themuse",
        "database.port": "5432",
        "plugin.name": "wal2json",
        "schema.whitelist": "public",
        "table.whitelist": "public.locations",
        "slot.drop_on_stop": "false",
        "transforms.route.type": "org.apache.kafka.connect.transforms.RegexRouter",
        "database.sslmode": "disable",
        "transforms.route.regex": "([^.]+)\\.([^.]+)\\.([^.]+)",
        "database.hostname": "host.docker.internal",
        "database.password": "dailymuse",
        "name": "debezium-postgresql",
        "transforms.route.replacement": "$1_$3",
        "snapshot.mode": "always",
        "database.tcpKeepAlive": "true"
    }
}
```
You'll want to `POST` that to `http://localhost:8083/connectors`.

Next you'll want to draft a sink config, again there is an example one in the Kafka repo but here is mine.

```json
{
    "name": "lol",
    "config": {
        "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
        "transforms.unwraps.type": "io.debezium.transforms.UnwrapFromEnvelope",
        "transforms.unwraps.drop.tombstones": "false",
        "transforms.unwraps.drop.deletes": "false",
        "table.name.format": "locations",
        "connection.password": "dailymuse",
        "tasks.max": "1",
        "topics": "themuse_locations",
        "transforms": "unwraps",
        "fields.whitelist": "value, latitude, longitude",
        "connection.user": "dailymuse",
        "name": "lol",
        "auto.create": "false",
        "connection.url": "jdbc:postgresql://host.docker.internal:5435/themuse",
        "insert.mode": "upsert",
        "pk.mode": "record_key",
        "pk.fields": "id"
    }
}
```
You'll want to `POST` that to `http://localhost:8083/connectors`.

After that is done make sure you have access to both databases via `psq` or some other tool. You'll want to test your sinks by adding or modifying a row to the source table you setup. Make sure that the data arrives in the sink database. Now you can try testing a delete and you should see the data change.

This work flow is basically how I tested these changes. It's important to remember however that whenever you change the jar a you'll need to rebuild the image, or your changes won't take effect.
